### PR TITLE
Don't recopy modules to tns_modules when bundling.

### DIFF
--- a/plugin/hooks/after-prepare-hook.js
+++ b/plugin/hooks/after-prepare-hook.js
@@ -74,7 +74,8 @@ module.exports = function(logger, platformsData, projectData, hookArgs) {
         var platformAppDirectory = path.join(platformsData.platformsData[platformName].appDestinationDirectoryPath, "app");
 
         if (!common.isSnapshotEnabled(projectData, hookArgs)) {
-            if (platformName === "android") {
+            var bundle = projectData.$options.bundle;
+            if (platformName === "android" && !bundle) {
                 // TODO: Fix this in the CLI if possible
                 if (shelljs.test("-e", path.join(projectData.projectDir, "node_modules", "@angular/core")) &&
                     !shelljs.test("-e", path.join(platformAppDirectory, "tns_modules", "@angular/core"))) {


### PR DESCRIPTION
Eliminates unneeded files that get copied to the device otherwise.

Without this fix, running nativescript-dev-webpack (which ultimately calls `tns ... --bundle`) gets us with a tns_modules dir that contains `@angular` subpackages only.

Ping @jasssonpet 