### PR TITLE
Change the existing tns-core-modules search logic

### DIFF
--- a/plugin/hooks/before-prepare-hook.js
+++ b/plugin/hooks/before-prepare-hook.js
@@ -8,11 +8,7 @@ var MIN_ANDROID_RUNTIME_VERSION_WITH_SNAPSHOT_SUPPORT = "2.1.0";
 
 function cleanSnapshotData(platformAppDirectory, projectData, snapshotPackageName) {
     // Force the CLI to return the deleted packages
-    if (!shelljs.test("-e", path.join(platformAppDirectory, "tns_modules/application")) ||
-        !shelljs.test("-e", path.join(platformAppDirectory, "tns_modules/tns-core-modules/application"))) {
-        shelljs.touch("-c", path.join(projectData.projectDir, "node_modules/nativescript-angular/package.json"));
-        shelljs.touch("-c", path.join(projectData.projectDir, "node_modules/tns-core-modules/package.json"));
-    }
+    common.prepareDeletedModules(platformAppDirectory, projectData.projectDir);
 
     shelljs.rm("-rf", path.join(platformAppDirectory, "_embedded_script_.js"));
     shelljs.rm("-rf", path.join(platformAppDirectory, "../snapshots"));

--- a/plugin/hooks/common.js
+++ b/plugin/hooks/common.js
@@ -4,6 +4,14 @@ var shelljs = require("shelljs");
 
 exports.environmentVariableToggleKey = "TNS_ANDROID_SNAPSHOT";
 
+exports.prepareDeletedModules = function(platformAppDirectory, projectDir) {
+    if (!shelljs.test("-e", path.join(platformAppDirectory, "tns_modules/application")) &&
+        !shelljs.test("-e", path.join(platformAppDirectory, "tns_modules/tns-core-modules/application"))) {
+        shelljs.touch("-c", path.join(projectDir, "node_modules/nativescript-angular/package.json"));
+        shelljs.touch("-c", path.join(projectDir, "node_modules/tns-core-modules/package.json"));
+    }
+};
+
 exports.isSnapshotEnabled = function(projectData, hookArgs) {
     if (hookArgs.platform !== "android") {
         return false;

--- a/plugin/preuninstall.js
+++ b/plugin/preuninstall.js
@@ -6,11 +6,7 @@ var common = require('./hooks/common');
 var projectDir = hook.findProjectDir();
 var platformAppDirectory = path.join(projectDir, "platforms/android/src/main/assets/app");
 
-if (!shelljs.test("-e", path.join(platformAppDirectory, "tns_modules/application")) ||
-    !shelljs.test("-e", path.join(platformAppDirectory, "tns_modules/tns-core-modules/application"))) {
-    shelljs.touch("-c", path.join(projectDir, "node_modules/nativescript-angular/package.json"));
-    shelljs.touch("-c", path.join(projectDir, "node_modules/tns-core-modules/package.json"));
-}
+common.prepareDeletedModules(platformAppDirectory, projectDir);
 
 common.executeInProjectDir(projectDir, function() {
     common.uninstallPackage({ name: "tns-core-modules-snapshot" });


### PR DESCRIPTION
Before it was checking if both directories were inexistent, now only one is enough.

ping @tzraikov, @ivanbuhov 