### PR TITLE
Fix plugin usage when {N} CLI is used as a library

### DIFF
--- a/plugin/hooks/after-prepare-hook.js
+++ b/plugin/hooks/after-prepare-hook.js
@@ -74,7 +74,7 @@ module.exports = function(logger, platformsData, projectData, hookArgs) {
         var platformAppDirectory = path.join(platformsData.getPlatformData(platformName).appDestinationDirectoryPath, "app");
 
         if (!common.isSnapshotEnabled(projectData, hookArgs)) {
-            var bundle = projectData.$options.bundle;
+            var bundle = hookArgs && hookArgs.appFilesUpdaterOptions ? hookArgs.appFilesUpdaterOptions.bundle : projectData.$options.bundle;
             if (platformName === "android" && !bundle) {
                 // TODO: Fix this in the CLI if possible
                 if (shelljs.test("-e", path.join(projectData.projectDir, "node_modules", "@angular/core")) &&

--- a/plugin/hooks/common.js
+++ b/plugin/hooks/common.js
@@ -13,19 +13,23 @@ exports.prepareDeletedModules = function(platformAppDirectory, projectDir) {
 };
 
 exports.isSnapshotEnabled = function(projectData, hookArgs) {
-    if (hookArgs.platform !== "android") {
+    var isAndroidPlatform = hookArgs && hookArgs.platform && hookArgs.platform.toLowerCase() === "android";
+    if (!isAndroidPlatform) {
         return false;
     }
+
+    var isReleaseBuild = hookArgs && hookArgs.appFilesUpdaterOptions ? hookArgs.appFilesUpdaterOptions.release : projectData.$options.release;
+    var shouldBundle = hookArgs && hookArgs.appFilesUpdaterOptions ? hookArgs.appFilesUpdaterOptions.bundle : projectData.$options.bundle;
 
     if (process.env[exports.environmentVariableToggleKey] === "0") {
         return false;
     }
 
-    if (projectData.$options.bundle) {
+    if (shouldBundle) {
         return false;
     }
 
-    if (projectData.$options.release || process.env[exports.environmentVariableToggleKey]) {
+    if (isReleaseBuild || process.env[exports.environmentVariableToggleKey]) {
         return true;
     }
 


### PR DESCRIPTION
The plugin hooks rely on `$options` object from CLI. This object is populated ONLY when CLI is used from command-line. However now we are able to build projects by requiring the CLI as a library.
In fact with `@next` version of CLI, the `release` and `bundle` options that the plugin uses from `$options` are available in the `hookArgs`. Use them and fallback to `$options` in case an older CLI (2.5.x for example) is used.